### PR TITLE
feat(ci): add automatic changelog and releases on npm

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+
+      - run: npm install -g semantic-release @semantic-release/git @semantic-release/changelog @semantic-release/release-notes-generator @semantic-release/npm
+
+      # needed for npm publishing
+      - run: npm run build
+
+      - run: semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.npm_token }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,9 @@
+{
+  "plugins": [
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/changelog",
+    "@semantic-release/git",
+    "@semantic-release/npm"
+  ],
+  "repositoryUrl": "https://github.com/narando/nest-xray"
+}


### PR DESCRIPTION
This enables an automatic generated changelog as well automatic publishing to npm.

@apricote I think you need to add  `npm_token` to the GitHub secrets