### PR TITLE
fix(ci): add missing step to release pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,8 @@ jobs:
         with:
           node-version: 12.x
 
+      - run: npm ci
+
       - run: npm install -g semantic-release @semantic-release/git @semantic-release/changelog @semantic-release/release-notes-generator @semantic-release/npm
 
       # needed for npm publishing


### PR DESCRIPTION
#2 was merged but [failed](https://github.com/narando/nest-xray/runs/391694691) because some dependencies were missing. This PR adds a `npm ci` step.