### PR TITLE
fix(ci): fix version in package.json

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -2,8 +2,8 @@
   "plugins": [
     "@semantic-release/release-notes-generator",
     "@semantic-release/changelog",
-    "@semantic-release/git",
-    "@semantic-release/npm"
+    "@semantic-release/npm",
+    "@semantic-release/git"
   ],
   "repositoryUrl": "https://github.com/narando/nest-xray"
 }


### PR DESCRIPTION
The npm release step modifies the `package.json` and publishes the artifacts to npm.

If the git step is ran before that, it will not contain the new `version` in `package.json` (See current [file](https://github.com/narando/nest-xray/blob/65311a5/package.json#L3)).

Running git after npm will publish the new version in package.json.