### PR TITLE
chore(renovate): schedule dep upgrades once a week

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,5 +6,5 @@
       "automerge": true
     }
   ],
-  "extends": ["config:base"]
+  "extends": ["config:base", "schedule:weekly"]
 }


### PR DESCRIPTION
Currently we have a huge number of PRs to update the dependencies,
this should reduce that number to improve on notification fatigue.