### PR TITLE
fix(clients/http): handle parallel subsegments

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,6 @@ The TracingCoreModule combines the `AsyncContext` with the official `AWSXRay` cl
 
 ## Known Bugs
 
-- Only one Subsegment can be persisted at a time. This causes issues when multiple outgoing http requests are made in parallel, some subsegments may never be marked as "finished".
 - The XRay Daemon Address can only be configured through the environment variable.
 
 ## License

--- a/lib/clients/http/http-tracing.module.ts
+++ b/lib/clients/http/http-tracing.module.ts
@@ -5,10 +5,10 @@ import {
   HttpService,
   Module,
 } from "@nestjs/common";
-import { AxiosTracingInterceptor } from "./axios-tracing.interceptor";
+import { TracingAxiosInterceptor } from "./tracing.axios-interceptor";
 
 @Module({
-  providers: [HttpService, AxiosTracingInterceptor],
+  providers: [HttpService, TracingAxiosInterceptor],
   exports: [HttpService],
 })
 export class HttpTracingModule {

--- a/lib/clients/http/tracing.axios-interceptor.spec.ts
+++ b/lib/clients/http/tracing.axios-interceptor.spec.ts
@@ -12,14 +12,14 @@ import { TracingNotInitializedException } from "../../exceptions";
 import {
   AxiosOnFulfilledInterceptor,
   AxiosOnRejectedInterceptor,
-  AxiosTracingInterceptor,
-} from "./axios-tracing.interceptor";
+  TracingAxiosInterceptor,
+} from "./tracing.axios-interceptor";
 import { HEADER_TRACE_CONTEXT } from "./http-tracing.constants";
 
-describe("AxiosTracingInterceptor", () => {
+describe("TracingAxiosInterceptor", () => {
   let testingModule: TestingModule;
 
-  let interceptor: AxiosTracingInterceptor;
+  let interceptor: TracingAxiosInterceptor;
   let tracingService: TracingService;
   let httpService: HttpService;
   let axios: AxiosInstance;
@@ -34,7 +34,7 @@ describe("AxiosTracingInterceptor", () => {
 
     testingModule = await Test.createTestingModule({
       providers: [
-        AxiosTracingInterceptor,
+        TracingAxiosInterceptor,
         {
           provide: TracingService,
           useFactory: () => ({}),
@@ -43,8 +43,8 @@ describe("AxiosTracingInterceptor", () => {
       ],
     }).compile();
 
-    interceptor = testingModule.get<AxiosTracingInterceptor>(
-      AxiosTracingInterceptor
+    interceptor = testingModule.get<TracingAxiosInterceptor>(
+      TracingAxiosInterceptor
     );
     tracingService = testingModule.get<TracingService>(TracingService);
     httpService = testingModule.get<HttpService>(HttpService);

--- a/lib/clients/http/tracing.axios-interceptor.ts
+++ b/lib/clients/http/tracing.axios-interceptor.ts
@@ -10,7 +10,7 @@ export type AxiosOnFulfilledInterceptor<T> = (value: T) => T | Promise<T>;
 export type AxiosOnRejectedInterceptor = (error: any) => any;
 
 @Injectable()
-export class AxiosTracingInterceptor implements OnModuleInit {
+export class TracingAxiosInterceptor implements OnModuleInit {
   constructor(
     private readonly tracingService: TracingService,
     private readonly httpService: HttpService

--- a/package-lock.json
+++ b/package-lock.json
@@ -1616,6 +1616,11 @@
         }
       }
     },
+    "@narando/nest-axios-interceptor": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@narando/nest-axios-interceptor/-/nest-axios-interceptor-1.1.0.tgz",
+      "integrity": "sha512-aLvqi85LxPNbmR4/mOQSGNoEovl/RrTvS95QcWrQZJMBEbez5zH98QkF870SAlQSf0u5+9XKFio3gRMyXS1bmQ=="
+    },
     "@nestjs/cli": {
       "version": "7.1.5",
       "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-7.1.5.tgz",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
+  "dependencies": {
+    "@narando/nest-axios-interceptor": "1.1.0"
+  },
   "peerDependencies": {
     "@nestjs/common": "^6.7.0 || ^7.0.0",
     "@nestjs/core": "^6.7.0 || ^7.0.0",


### PR DESCRIPTION
Currently the `AxiosTracingInterceptor` uses `tracingService.setSubSegment` to persist the subsegment and make it available to later interceptors. This causes issues when there is one more than 1 request in parallel, as `tracingSerivce.setSubSegment` can only save one subsegment at a time.

In this PR we use the new `@narando/nest-axios-interceptor` package to implement the axios interceptor and save the subsegment to the request config, which is unique per request.