### PR TITLE
fix(client/http): TracingService not available in module context

### DIFF
--- a/lib/clients/http/http-tracing.module.ts
+++ b/lib/clients/http/http-tracing.module.ts
@@ -5,9 +5,11 @@ import {
   HttpService,
   Module,
 } from "@nestjs/common";
+import { TracingCoreModule } from "../../core";
 import { TracingAxiosInterceptor } from "./tracing.axios-interceptor";
 
 @Module({
+  imports: [TracingCoreModule],
   providers: [HttpService, TracingAxiosInterceptor],
   exports: [HttpService],
 })

--- a/lib/core/core.module.ts
+++ b/lib/core/core.module.ts
@@ -1,4 +1,4 @@
-import { DynamicModule, Module, Global } from "@nestjs/common";
+import { DynamicModule, Module } from "@nestjs/common";
 import * as AWSXRay from "aws-xray-sdk";
 import { AsyncHooksModule } from "../async-hooks";
 import { XRAY_CLIENT } from "./constants";
@@ -23,6 +23,7 @@ import { TracingService } from "./tracing.service";
 export class TracingCoreModule {
   static forRoot(options: TracingConfig): DynamicModule {
     return {
+      global: true,
       module: TracingCoreModule,
       providers: [{ provide: TracingConfig, useValue: options }],
     };

--- a/lib/tracing.module.ts
+++ b/lib/tracing.module.ts
@@ -1,4 +1,4 @@
-import { DynamicModule, Global, Module } from "@nestjs/common";
+import { DynamicModule, Module } from "@nestjs/common";
 import { AsyncHooksModule } from "./async-hooks";
 import { TracingCoreModule } from "./core";
 import { TracingConfig } from "./core/interfaces";
@@ -10,6 +10,8 @@ import { HttpEnvironmentModule } from "./environments/http";
 export class TracingModule {
   public static forRoot(options: TracingConfig): DynamicModule {
     return {
+      // Make TracingService available in the whole app
+      global: true,
       module: TracingModule,
       imports: [TracingCoreModule.forRoot(options)],
       exports: [TracingCoreModule],


### PR DESCRIPTION
Fixes this error:

```
Error: Nest can't resolve dependencies of the AxiosTracingInterceptor (?, HttpService). Please make sure that the argument TracingService at index [0] is available in the HttpTracingModule context.

Potential solutions:
- If TracingService is a provider, is it part of the current HttpTracingModule?
- If TracingService is exported from a separate @Module, is that module imported within HttpTracingModule?
  @Module({
    imports: [ /* the Module containing TracingService */ ]
  })

    at Injector.lookupComponentInExports (/app/node_modules/@nestjs/core/injector/injector.js:183:19)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
```

We want to make the `TracingService` available to all child modules when loading the module with `TracingModule.forRoot`.