### PR TITLE
fix(client/http): error when used in context without Segment

### DIFF
--- a/lib/clients/http/tracing.axios-interceptor.spec.ts
+++ b/lib/clients/http/tracing.axios-interceptor.spec.ts
@@ -95,6 +95,7 @@ describe("TracingAxiosInterceptor", () => {
     it("should persist the subsegment to the request config", () => {
       interceptorFn(config);
 
+      // @ts-ignore
       expect(config[TRACING_CONFIG_KEY].subSegment).toBe(subSegment);
     });
 
@@ -206,6 +207,7 @@ describe("TracingAxiosInterceptor", () => {
     });
 
     it("should do nothing if no subsegment was saved", () => {
+      // @ts-ignore
       response.config[TRACING_CONFIG_KEY] = {};
 
       expect(interceptorFn(response)).toEqual(response);
@@ -291,6 +293,7 @@ describe("TracingAxiosInterceptor", () => {
     });
 
     it("should do nothing if no subsegment is returned", () => {
+      // @ts-ignore
       error.config[TRACING_CONFIG_KEY] = {};
 
       expect(() => interceptorFn(error)).toThrow(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "sourceMap": true,
     "outDir": "./dist",
     "baseUrl": "./",
-    "incremental": true
+    "incremental": true,
+    "strict": true
   },
   "include": ["lib/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
When the client was used in a code path without a Segment, the creation of the Subsegment failed but the error was silently caught (as intended).

In the later interceptor functions, the client crashed when accessing the missing property `config[TRACING_CONFIG_KEY]`. By explicitly checking if it is set, we avoid this bug.

Additionally I also activated the typescript strict mode, to catch such bugs in the future.