### PR TITLE
feat(core): allow setting custom XRay plugins

### DIFF
--- a/lib/core/interfaces/tracing-config.interface.ts
+++ b/lib/core/interfaces/tracing-config.interface.ts
@@ -1,3 +1,5 @@
+import { plugins } from "aws-xray-sdk";
+
 export class TracingConfig {
   /**
    * Name of the current service.
@@ -18,4 +20,9 @@ export class TracingConfig {
    * This is only documented in the README in section "Known Bugs".
    */
   public daemonAddress?: string;
+
+  /**
+   * Enables use of plugins to capture additional data for segments.
+   */
+  public plugins?: plugins.Plugin[];
 }


### PR DESCRIPTION
We hard-coded the `EC2` and `ECS` plugins because we needed those at narando.

By making it configurable the plugin can be more easily adopted in other environments without overcomplicating things. Also, the `EC2` plugin crashes in Github Actions.

We will keep the `EC2` and `ECS` as the default plugins to not break compatibility, but this will change with the next major version.