### PR TITLE
fix: duplicate TracingService instances without configuration

### DIFF
--- a/lib/clients/http/http-tracing.module.ts
+++ b/lib/clients/http/http-tracing.module.ts
@@ -5,11 +5,9 @@ import {
   HttpService,
   Module,
 } from "@nestjs/common";
-import { TracingCoreModule } from "../../core";
 import { TracingAxiosInterceptor } from "./tracing.axios-interceptor";
 
 @Module({
-  imports: [TracingCoreModule],
   providers: [HttpService, TracingAxiosInterceptor],
   exports: [HttpService],
 })

--- a/lib/environments/http/http-environment.module.ts
+++ b/lib/environments/http/http-environment.module.ts
@@ -1,12 +1,11 @@
-import { MiddlewareConsumer, Module, NestModule, Global } from "@nestjs/common";
+import { Global, MiddlewareConsumer, Module, NestModule } from "@nestjs/common";
 import { AsyncHooksModule } from "../../async-hooks";
-import { TracingCoreModule } from "../../core";
 import { AsyncHooksMiddleware } from "./async-hooks.middleware";
 import { HttpTracingMiddleware } from "./tracing.middleware";
 
 // this module is global to ensure that middlewares are only called once
 @Global()
-@Module({ imports: [AsyncHooksModule, TracingCoreModule] })
+@Module({ imports: [AsyncHooksModule] })
 export class HttpEnvironmentModule implements NestModule {
   public configure(consumer: MiddlewareConsumer) {
     consumer


### PR DESCRIPTION
By directly importing the `TracingCoreModule` in other modules in the package
the `TracingService` gets instantiated multiple times.

Only with `TracingCoreModule.forRoot()` the configuration is properly set, so these additional instances will use default values for everything.

Because we only have one singleton instance of `XRayClient` and write configuration to it, the user-desired configuration gets overriden by this broken behaviour.