### PR TITLE
fix(docs): fix broken module name

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ This module implements [Distributed Tracing](https://opentracing.io/docs/overvie
 
 ### Installation
 
-Install this module and `aws-sdk-xray`:
+Install this module and `aws-xray-sdk`:
 
 ```shell
-$ npm i @narando/nest-xray aws-sdk-xray
+$ npm i @narando/nest-xray aws-xray-sdk
 ```
 
 ### Initialization


### PR DESCRIPTION
Peer dependency of this module named `aws-xray-sdk` is incorrectly written as `aws-sdk-xray` on `README.md`.

This can cause slightly little discomfort when anyone just copy and paste to install module as instruction on `README` :)

```shell
ME % npm i @narando/nest-xray aws-sdk-xray

npm ERR! code E404
npm ERR! 404 Not Found - GET https://registry.npmjs.org/aws-sdk-xray - Not found
npm ERR! 404 
npm ERR! 404  'aws-sdk-xray@latest' is not in the npm registry.
npm ERR! 404 You should bug the author to publish it (or use the name yourself!)
```