### PR TITLE
fix(env/http): segment has invalid URL when sampling decision is made

### DIFF
--- a/lib/environments/http/http-environment.module.ts
+++ b/lib/environments/http/http-environment.module.ts
@@ -10,8 +10,8 @@ export class HttpEnvironmentModule implements NestModule {
   public configure(consumer: MiddlewareConsumer) {
     consumer
       .apply(AsyncHooksMiddleware)
-      .forRoutes("*")
+      .forRoutes("/")
       .apply(HttpTracingMiddleware)
-      .forRoutes("*");
+      .forRoutes("/");
   }
 }

--- a/lib/environments/http/tracing.middleware.spec.ts
+++ b/lib/environments/http/tracing.middleware.spec.ts
@@ -42,9 +42,8 @@ describe("HttpTracingMiddleware", () => {
       req = {
         segment: {
           id: 1337,
-          http: { request: { url: "https://example.com/" } },
+          http: { request: { url: "https://example.com/path?foo=bar" } },
         },
-        originalUrl: "/path",
       };
       res = {};
       next = jest.fn();
@@ -63,7 +62,7 @@ describe("HttpTracingMiddleware", () => {
       );
     });
 
-    it("should patch the segment http url", async () => {
+    it("should remove the query string", async () => {
       await new Promise((resolve) => tracingMiddleware.use(req, res, resolve));
 
       expect(req.segment.http.request.url).toEqual("https://example.com/path");


### PR DESCRIPTION
## Issue

The xray-sdk makes the decision wether to sample the trace or not during the initial call to the middleware. The way we setup the middleware, express would actually rewrite `req.url` to `"/"`, which we fix afterwards, but the sampling decision is being made with the empty path, which breaks the rules.

## Fix

By applying the middleware to path pattern `"*"`, express will replace the `req.url` property with `"/"`.

We can avoid this workaround by registering the middleware to `"/"`, this way express will not replace any part of `req.url`.

A similar error from nestjs/nest that describes a similar issue and why express does it that way: https://github.com/nestjs/nest/issues/4315