### PR TITLE
chore: update browserslist db

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4158,9 +4158,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001228",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz",
-      "integrity": "sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A==",
+      "version": "1.0.30001299",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001299.tgz",
+      "integrity": "sha512-iujN4+x7QzqA2NCSrS5VUy+4gLmRd4xv6vbBBsmfVqTx8bLAD8097euLqQgKxSVLvxjSDcvF1T/i9ocgnUFexw==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -16187,9 +16187,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001228",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz",
-      "integrity": "sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A==",
+      "version": "1.0.30001299",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001299.tgz",
+      "integrity": "sha512-iujN4+x7QzqA2NCSrS5VUy+4gLmRd4xv6vbBBsmfVqTx8bLAD8097euLqQgKxSVLvxjSDcvF1T/i9ocgnUFexw==",
       "dev": true
     },
     "chalk": {


### PR DESCRIPTION
```bash
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating
Latest version:     1.0.30001299
Installed version:  1.0.30001228
Removing old caniuse-lite from lock file
Installing new caniuse-lite version
$ npm install caniuse-lite
Cleaning package.json dependencies from caniuse-lite
$ npm uninstall caniuse-lite
caniuse-lite has been successfully updated

Target browser changes:
- and_chr 90
+ and_chr 96
- and_ff 87
+ and_ff 95
- android 90
+ android 96
- chrome 90
- chrome 89
- chrome 88
+ chrome 97
+ chrome 96
+ chrome 95
+ chrome 94
- edge 90
- edge 89
+ edge 97
+ edge 96
- firefox 88
- firefox 87
+ firefox 96
+ firefox 95
+ firefox 94
- ios_saf 14.5
- ios_saf 13.4-13.7
+ ios_saf 15.2
+ ios_saf 15.0-15.1
+ ios_saf 14.5-14.8
+ ios_saf 12.2-12.5
- op_mob 62
+ op_mob 64
- opera 75
- opera 74
+ opera 82
+ opera 81
- safari 14
+ safari 15.2
+ safari 15.1
+ safari 13.1
- samsung 13.0
+ samsung 15.0
```